### PR TITLE
Add embedded svg from a configurable source

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ emoji:
 
 The following formats are supported: `html`, `unicode`, `emojione-png`, ` emojione-svg`, and `emojione-svg-embed`.
 
-The `src` attribute can be used to point to a location of the set of emojis that are named the same way the EmojiOne images are, eg `https://cdn.jsdelivr.net/emojione/assets/#{ext}/#{unicode}.#{ext}`. When using it with `emojione-png` or `emojione-svg`, the `<img>` src will point to images at this location.  
+The `src` attribute can only be used with `emojione-png`, ` emojione-svg`, and `emojione-svg-embed` and can be used to point to a location of a set of emojis that are named the same way the EmojiOne images are, eg `https://cdn.jsdelivr.net/emojione/assets/#{ext}/#{unicode}.#{ext}`. When using it with `emojione-png` or `emojione-svg`, the `<img>` src will point to images at this location.  
 
 For example, `src: "/assets/images/emojis"` will produce `<img>` tags similar to `<img class="emojione" alt="🍺" src="/assets/imgs/emojis/1f37a.svg">` whilst `src: "https://twemoji.maxcdn.com/svg"` will produce `<img>` tags similar to `<img class="emojione" alt="🍺" src="https://twemoji.maxcdn.com/svg/1f37a.svg">` using Twemoji's CDN-hosted images.
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,16 @@ emoji:
   format: emojione-svg # default html
   ascii: true # default false
   shortname: true # default true
+  src: "/assets/imgs/emojis" # defaults to "https://cdn.jsdelivr.net/emojione/assets/#{ext}"
 ~~~
 
-The following formats are supported: `html`, `unicode`, `emojione-png`, and ` emojione-svg`.
+The following formats are supported: `html`, `unicode`, `emojione-png`, ` emojione-svg`, and `emojione-svg-embed`.
+
+The `src` attribute can be used to point to a location of the set of emojis that are named the same way the EmojiOne images are, eg `https://cdn.jsdelivr.net/emojione/assets/#{ext}/#{unicode}.#{ext}`. When using it with `emojione-png` or `emojione-svg`, the `<img>` src will point to images at this location.  
+
+For example, `src: "/assets/images/emojis"` will produce `<img>` tags similar to `<img class="emojione" alt="🍺" src="/assets/imgs/emojis/1f37a.svg">` whilst `src: "https://twemoji.maxcdn.com/svg"` will produce `<img>` tags similar to `<img class="emojione" alt="🍺" src="https://twemoji.maxcdn.com/svg/1f37a.svg">` using Twemoji's CDN-hosted images.
+
+When used with `emojione-svg-embed`, the SVG in the file at this location will be embedded into your content.
 
 For a list of all available shortnames and asciimojis (I hope I coined this, so I can be cool) you can consult the [emoji.codes](http://emoji.codes),
 [Emoji One](http://emojione.com), and
@@ -61,6 +68,8 @@ There's also a Liquid filter called `emojify`. It accepts three parameters: `for
 ### `emojify` filter performance
 
 The `emojify` filter deteriorates performance *a little* under very *specific* conditions; it shouldn't be an issue, but in case you see performance degradation when generating the site&mdash;start with this.
+
+The `emojify` filter will result in a drop in site generation performance if you specific a `src` that points to a URL as the content of each SVG will need to be downloaded from that location.
 
 ### `emojify` filter unawareness
 

--- a/jekyll-emoji.gemspec
+++ b/jekyll-emoji.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "jekyll", ">= 2.0"
   spec.add_dependency "yajl-ruby", "~> 1.2", '>= 1.2.0'
   spec.add_dependency "oga", "~> 1.2", '>= 1.2.0'
+  spec.add_dependency "httpclient", ">=2.7"
 end

--- a/lib/jekyll/emoji/converter.rb
+++ b/lib/jekyll/emoji/converter.rb
@@ -388,13 +388,22 @@ module Jekyll
       #
       def emojione_img_node(codepoints)
         ext = @conf['format'].split('-').last
-        img_src = @conf['src'] ||= "https://cdn.jsdelivr.net/emojione/assets/#{ext}"
+        img_src = @conf['src'] || "https://cdn.jsdelivr.net/emojione/assets/#{ext}"
         img = Oga::XML::Element.new name: 'img'
         img.set('class', 'emojione')
         img.set('alt', codepoints_to_unicode(codepoints))
         img.set('src', "#{img_src}/#{codepoints}.#{ext}")
 
         return img
+      end
+
+      ##
+      # Generates a populated {Oga::XML::Element} node.
+      #
+      # @param [String|Array] codepoints
+      # @return [Oga::XML::Element(name:svg)]
+      def emojione_svg_embed_node(codepoints)
+        svg_src = @conf['src'] || "https://cdn.jsdelivr.net/emojione/assets/#{ext}"
       end
 
       ##

--- a/lib/jekyll/emoji/converter.rb
+++ b/lib/jekyll/emoji/converter.rb
@@ -1,7 +1,7 @@
 require "jekyll/emoji/version"
 require 'oga'
 require 'yajl'
-require 'HTTPClient'
+require 'httpclient'
 
 module Jekyll
   module Emoji

--- a/lib/jekyll/emoji/converter.rb
+++ b/lib/jekyll/emoji/converter.rb
@@ -37,6 +37,7 @@ module Jekyll
         unicode
         emojione-png
         emojione-svg
+        emojione-svg-embed
       }
 
       EMOJI_JSON_FILE = '../../../../emoji.json'
@@ -387,10 +388,11 @@ module Jekyll
       #
       def emojione_img_node(codepoints)
         ext = @conf['format'].split('-').last
+        img_src = @conf['src'] ||= "https://cdn.jsdelivr.net/emojione/assets/#{ext}"
         img = Oga::XML::Element.new name: 'img'
         img.set('class', 'emojione')
         img.set('alt', codepoints_to_unicode(codepoints))
-        img.set('src', "https://cdn.jsdelivr.net/emojione/assets/#{ext}/#{codepoints}.#{ext}")
+        img.set('src', "#{img_src}/#{codepoints}.#{ext}")
 
         return img
       end

--- a/lib/jekyll/emoji/converter.rb
+++ b/lib/jekyll/emoji/converter.rb
@@ -12,7 +12,8 @@ module Jekyll
       DEFAULTS = {
         'format' => 'html',
         'ascii' => false,
-        'shortname' => true
+        'shortname' => true,
+        'src' => nil
       }.freeze
 
       BLACKLIST_ATTRIBUTES = %w{

--- a/lib/jekyll/emoji/converter.rb
+++ b/lib/jekyll/emoji/converter.rb
@@ -414,7 +414,7 @@ module Jekyll
       # @return [Oga::XML::Element(name:svg)]
       def emojione_svg_embed_node(codepoints)
         if @conf['src']
-          data = File.open("#{@conf['src']}/#{codepoints}.svg")
+          data = File.open("#{@conf['src'].chomp('/')}/#{codepoints}.svg")
         else
           data = Enumerator.new do |yielder|
             HTTPClient.get("https://cdn.jsdelivr.net/emojione/assets/svg/#{codepoints}.svg") do |chunk|

--- a/lib/jekyll/emoji/converter.rb
+++ b/lib/jekyll/emoji/converter.rb
@@ -413,14 +413,16 @@ module Jekyll
       # @param [String|Array] codepoints
       # @return [Oga::XML::Element(name:svg)]
       def emojione_svg_embed_node(codepoints)
-        if @conf['src']
-          data = File.open("#{@conf['src'].chomp('/')}/#{codepoints}.svg")
-        else
+        base = @conf['src'] || "https://cdn.jsdelivr.net/emojione/assets/svg"
+
+        if base =~ /^(http|https):\/\/[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(([0-9]{1,5})?\/.*)?$/ix
           data = Enumerator.new do |yielder|
-            HTTPClient.get("https://cdn.jsdelivr.net/emojione/assets/svg/#{codepoints}.svg") do |chunk|
+            HTTPClient.get("#{base.chomp('/')}/#{codepoints}.svg") do |chunk|
               yielder << chunk
             end
           end
+        else
+          data = File.open("#{base.chomp('/')}/#{codepoints}.svg")
         end
         img = Oga.parse_xml(data).children[0]
         img.set('class', 'emojione')

--- a/lib/jekyll/emoji/filter.rb
+++ b/lib/jekyll/emoji/filter.rb
@@ -10,7 +10,7 @@ module Jekyll
       # @param [String] output_format
       # @param [FalseClass|TrueClass|NilClass] ascii
       # @param [FalseClass|TrueClass|NilClass] shortname
-      # @param [FalseClass|TrueClass|NilClass] src
+      # @param [String|NilClass] src
       # @return [String]
       #
       def emojify(input, output_format = nil, ascii = nil, shortname = nil, src = nil)

--- a/lib/jekyll/emoji/filter.rb
+++ b/lib/jekyll/emoji/filter.rb
@@ -10,12 +10,13 @@ module Jekyll
       # @param [String] output_format
       # @param [FalseClass|TrueClass|NilClass] ascii
       # @param [FalseClass|TrueClass|NilClass] shortname
+      # @param [FalseClass|TrueClass|NilClass] src
       # @return [String]
       #
-      def emojify(input, output_format = nil, ascii = nil, shortname = nil)
+      def emojify(input, output_format = nil, ascii = nil, shortname = nil, src = nil)
         # Liquid/Jekyll seem to re-create the class where filters are included
         @@__emoji_converter__ ||= Converter.new(@context.registers[:site].config)
-        @@__emoji_converter__.reconfigure('format' => output_format, 'ascii' => ascii, 'shortname' => shortname)
+        @@__emoji_converter__.reconfigure('format' => output_format, 'ascii' => ascii, 'shortname' => shortname, 'src' => src)
 
         output = @@__emoji_converter__.convert(input)
 

--- a/tests/conversion_test.rb
+++ b/tests/conversion_test.rb
@@ -32,6 +32,22 @@ class TestConversion < MiniTest::Test
     assert_equal "the number 3 is smaller than 4", @converter.convert("the number 3 is smaller than 4")
   end
 
+  def test_src
+    @converter.reconfigure 'format' => 'emojione-svg', 'src' => '/assets/svg'
+    img = %Q{the number <img class="emojione" alt="3\u{20e3}" src="/assets/svg/0033-20e3.svg" /> is smaller than 4}
+    assert_equal img, @converter.convert("the number \u{0033}\u{20E3} is smaller than 4")
+    assert_equal img, @converter.convert("the number :three: is smaller than 4")
+    assert_equal "the number 3 is smaller than 4", @converter.convert("the number 3 is smaller than 4")
+  end
+
+  def test_svg_embed
+    @converter.reconfigure 'format' => 'emojione-svg-embed'
+    img = %Q{the number <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" enable-background="new 0 0 64 64" class="emojione" alt="3\u{20e3}"><path fill="#d0d0d0" d="m61.978 51.994c0 5.523-4.478 10-10 10h-40c-5.522 0-10-4.477-10-10v-40c0-5.523 4.478-10 10-10h40c5.522 0 10 4.477 10 10v40"></path><path fill="#fff" d="m56.978 45.66c0 4.604-3.731 8.334-8.333 8.334h-33.33c-4.602 0-8.333-3.73-8.333-8.334v-33.33c0-4.604 3.731-8.334 8.333-8.334h33.33c4.602 0 8.333 3.73 8.333 8.334v33.33"></path><path fill="#9aa0a5" d="m21.978 36.15l5.585-.707c.179 1.482.657 2.617 1.438 3.4s1.725 1.176 2.834 1.176c1.19 0 2.193-.471 3.01-1.41.814-.941 1.223-2.209 1.223-3.807 0-1.51-.391-2.707-1.172-3.59-.781-.885-1.731-1.324-2.854-1.324-.74 0-1.623.148-2.65.447l.637-4.895c1.561.043 2.752-.311 3.573-1.059s1.232-1.742 1.232-2.982c0-1.055-.301-1.896-.903-2.521-.603-.627-1.404-.941-2.403-.941-.985 0-1.827.355-2.525 1.068s-1.122 1.752-1.273 3.121l-5.317-.939c.369-1.896.928-3.41 1.674-4.543.745-1.133 1.785-2.023 3.121-2.672 1.334-.648 2.83-.973 4.486-.973 2.833 0 5.106.939 6.816 2.822 1.41 1.539 2.115 3.275 2.115 5.215 0 2.75-1.444 4.945-4.332 6.584 1.725.385 3.104 1.246 4.138 2.586 1.033 1.34 1.55 2.957 1.55 4.854 0 2.75-.965 5.094-2.895 7.03-1.932 1.938-4.334 2.908-7.208 2.908-2.724 0-4.983-.816-6.776-2.447-1.795-1.633-2.835-3.768-3.123-6.402"></path></svg> is smaller than 4}
+    assert_equal img, @converter.convert("the number \u{0033}\u{20E3} is smaller than 4")
+    assert_equal img, @converter.convert("the number :three: is smaller than 4")
+    assert_equal "the number 3 is smaller than 4", @converter.convert("the number 3 is smaller than 4")
+  end
+
   def test_reconfiguring_aliases
     @converter.reconfigure 'ascii' => false
     assert_equal ":)", @converter.convert(":)")


### PR DESCRIPTION
I like my emojis to be the embedded SVG code rather than adding many more calls to an external server.

This PR adds this functionality.

I've also updated the README and added tests for this functionality.
